### PR TITLE
:bug: Expires checkout session when creating a new one + adds an expired status

### DIFF
--- a/commercialisation/payment/lib/Stripe.l.php
+++ b/commercialisation/payment/lib/Stripe.l.php
@@ -89,6 +89,12 @@ class StripeLib {
 
 	}
 
+	public static function expiresCheckoutSession(StripeFarm $eStripeFarm, string $sessionId): array {
+
+		return self::sendStripeRequest($eStripeFarm, 'checkout/sessions/'.$sessionId.'/expire');
+
+	}
+
 	public static function getStripeCheckoutSessionFromPaymentIntent(StripeFarm $eStripeFarm, string $paymentIntentId) {
 
 		$arguments = [

--- a/commercialisation/selling/module/Payment.m.php
+++ b/commercialisation/selling/module/Payment.m.php
@@ -10,6 +10,7 @@ abstract class PaymentElement extends \Element {
 	const INITIALIZED = 'initialized';
 	const SUCCESS = 'success';
 	const FAILURE = 'failure';
+	const EXPIRED = 'expired';
 
 	public static function getSelection(): array {
 		return Payment::model()->getProperties();
@@ -48,7 +49,7 @@ class PaymentModel extends \ModuleModel {
 			'method' => ['element32', 'payment\Method', 'null' => TRUE, 'cast' => 'element'],
 			'checkoutId' => ['text8', 'null' => TRUE, 'unique' => TRUE, 'cast' => 'string'],
 			'paymentIntentId' => ['text8', 'null' => TRUE, 'unique' => TRUE, 'cast' => 'string'],
-			'onlineStatus' => ['enum', [\selling\Payment::INITIALIZED, \selling\Payment::SUCCESS, \selling\Payment::FAILURE], 'null' => TRUE, 'cast' => 'enum'],
+			'onlineStatus' => ['enum', [\selling\Payment::INITIALIZED, \selling\Payment::SUCCESS, \selling\Payment::FAILURE, \selling\Payment::EXPIRED], 'null' => TRUE, 'cast' => 'enum'],
 			'createdAt' => ['datetime', 'cast' => 'string'],
 		]);
 

--- a/commercialisation/selling/selling.yml
+++ b/commercialisation/selling/selling.yml
@@ -201,7 +201,7 @@ Payment:
   method: ?payment\Method
   checkoutId: ?text8
   paymentIntentId: ?text8
-  onlineStatus: ?enum(INITIALIZED, SUCCESS, FAILURE)
+  onlineStatus: ?enum(INITIALIZED, SUCCESS, FAILURE, EXPIRED)
   createdAt: datetime = SPECIAL(now)
   INDEX: [
     ["farm"],

--- a/commercialisation/shop/lib/Sale.l.php
+++ b/commercialisation/shop/lib/Sale.l.php
@@ -485,6 +485,8 @@ class SaleLib {
 		$ePayment = \selling\PaymentLib::createBySale($eSale, $eMethod, $stripeSession['id']);
 		\selling\HistoryLib::createBySale($eSale, 'shop-payment-initiated', 'Stripe checkout id #'.$stripeSession['id'], ePayment: $ePayment);
 
+		\selling\PaymentLib::expiresPaymentSessions($eStripeFarm, $eSale, $eMethod, $stripeSession['id']);
+
 		\selling\Sale::model()->commit();
 
 		return $stripeSession['url'];


### PR DESCRIPTION
Pour prévenir les double paiements (remontés par une ferme dans le 43) : 
- on expire les autres checkout session qui sont initialisées pour la même vente
- on passe les paiements concernés dans un statut "expiré" sur OTF.